### PR TITLE
update go and dependencies

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.24.5
+golang 1.26.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Run
+
+```bash
+go build -o auth ./cmd/auth   # build binary
+go vet ./...                   # lint
+```
+
+No test files exist in this codebase.
+
+### Required environment variables
+
+| Variable | Description |
+|---|---|
+| `SQL_URL` | PostgreSQL connection string |
+| `OAUTH2_CLIENT_ID` | Google OAuth app client ID |
+| `OAUTH2_CLIENT_SECRET` | Google OAuth app client secret |
+| `PORT` | Listen port (default: `8080`) |
+
+## Architecture
+
+This is a minimal OAuth2 authentication service for Deploys.app. It acts as an OAuth2 authorization server backed by Google as the identity provider.
+
+### Entry point
+
+`cmd/auth/main.go` reads env vars, opens a PostgreSQL connection, registers handlers on a `http.ServeMux`, wraps it with `pgctx.Middleware` (binds the DB to each request context), and calls `http.ListenAndServe`.
+
+### HTTP endpoints
+
+| Method | Path | Handler | Purpose |
+|---|---|---|---|
+| `GET` | `/` | `RedirectHandler` | Validates the OAuth2 client and redirects the user to Google |
+| `GET` | `/callback` | `CallbackHandler` | Receives Google's code, exchanges it for an ID token, issues an internal auth code |
+| `POST` | `/token` | `TokenHandler` | Exchanges client credentials + internal code for a long-lived user token |
+| `POST` | `/revoke` | `RevokePostHandler` | Deletes a user token by its hash |
+
+### Database access pattern
+
+`github.com/acoshift/pgsql` / `pgctx` is the only DB layer. Calling `pgctx.Middleware(db)` stores the `*sql.DB` in the request context; handlers then call `pgctx.Exec(ctx, ...)` or `pgctx.QueryRow(ctx, ...)` directly — there is no ORM or repository struct.
+
+All DB logic lives in `oauth2.go` (session/code helpers) and `token.go` (token hashing and persistence).
+
+### Session & token lifecycle
+
+- **OAuth2 sessions** (`oauth2_sessions`) — created by `RedirectHandler`, deleted on first read by `CallbackHandler`. 1-hour TTL enforced in the WHERE clause.
+- **OAuth2 codes** (`oauth2_codes`) — created by `CallbackHandler`, consumed atomically (DELETE … RETURNING) by `TokenHandler`. 1-hour TTL.
+- **User tokens** (`user_tokens`) — 7-day TTL, stored as SHA-256 hashes. Revoked by `RevokePostHandler`.
+
+### Key decisions
+
+- No framework — plain `net/http` + `http.ServeMux`.
+- No test files; no graceful shutdown / signal handling.
+- Google is the only upstream identity provider (hardcoded endpoints in `handler.go`).
+- Docker image uses `gcr.io/distroless/static` for a minimal runtime.
+- CI builds and pushes to `registry.moonrhythm.io/deploys-app/auth:<git-sha>`.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/deploys-app/auth
 
-go 1.24.5
+go 1.26.3
 
 require (
-	github.com/acoshift/pgsql v0.15.3
-	github.com/lib/pq v1.10.9
+	github.com/acoshift/pgsql v0.16.0
+	github.com/lib/pq v1.12.3
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/acoshift/pgsql v0.15.3 h1:iQjsvb4RXFWeinATQBjjGRZomkMD7B0fHxyq4bnkh0A=
-github.com/acoshift/pgsql v0.15.3/go.mod h1:HtdMa77CYeRb9pD6+cT/ZPjpudiUVQ2OIKv6QXjgEZw=
+github.com/acoshift/pgsql v0.16.0 h1:ak+fwy8Xnx0uZBhSmvFhGGk3a7EQNu8IiRLpnP99IT4=
+github.com/acoshift/pgsql v0.16.0/go.mod h1:HtdMa77CYeRb9pD6+cT/ZPjpudiUVQ2OIKv6QXjgEZw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
-github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
+github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=


### PR DESCRIPTION
## Summary

- Go `1.24.5` → `1.26.3` (go.mod + .tool-versions)
- `github.com/acoshift/pgsql` `v0.15.3` → `v0.16.0`
- `github.com/lib/pq` `v1.10.9` → `v1.12.3`

Also adds `CLAUDE.md` with codebase guidance for Claude Code.

## Test plan

- [ ] `go build ./...` passes (verified locally)