### PR TITLE
ci: add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,24 @@
+name: Deploy
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+    branches: [main]
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+    - uses: google-github-actions/auth@v1
+      with:
+        credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+    - uses: google-github-actions/get-gke-credentials@v2
+      with:
+        project_id: ${{ vars.GKE_PROJECT }}
+        cluster_name: ${{ vars.GKE_CLUSTER }}
+        location: ${{ vars.GKE_LOCATION }}
+    - name: Deploy
+      env:
+        IMAGE: asia-southeast1-docker.pkg.dev/deploys-app/internal/auth:${{ github.event.workflow_run.head_sha }}
+      run: kubectl set image -n deployer deployment/auth app=$IMAGE


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yaml` to roll out the auth service after a successful Build on `main`.
- Follows the same pattern as the registry and dropbox repos: `google-github-actions/auth` → `get-gke-credentials` → `kubectl set image -n deployer deployment/auth app=...:<sha>`.

## Test plan
- [ ] Merge to `main`, confirm the existing `Build` workflow runs to completion.
- [ ] Confirm the new `Deploy` workflow triggers on Build success, authenticates to GKE, and updates the `auth` deployment image to the new SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)