### PR TITLE
refactor: collapse cmd/auth into root package main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build & Run
 
 ```bash
-go build -o auth ./cmd/auth   # build binary
+go build -o auth .             # build binary
 go vet ./...                   # lint
 ```
 
@@ -26,7 +26,7 @@ This is a minimal OAuth2 authentication service for Deploys.app. It acts as an O
 
 ### Entry point
 
-`cmd/auth/main.go` reads env vars, opens a PostgreSQL connection, registers handlers on a `http.ServeMux`, wraps it with `pgctx.Middleware` (binds the DB to each request context), and calls `http.ListenAndServe`.
+`main.go` reads env vars, opens a PostgreSQL connection, registers handlers on a `http.ServeMux`, wraps it with `pgctx.Middleware` (binds the DB to each request context), and calls `http.ListenAndServe`. All Go files live in the project root under `package main`.
 
 ### HTTP endpoints
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN asdf install
 ADD go.mod go.sum ./
 RUN go mod download
 ADD . .
-RUN go build -o .build/auth -ldflags "-w -s" ./cmd/auth
+RUN go build -o .build/auth -ldflags "-w -s" .
 
 FROM gcr.io/distroless/static
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,42 @@
 # Deploys.app - Auth
 
-## Development
+Minimal OAuth2 authentication service for Deploys.app. Acts as an OAuth2
+authorization server backed by Google as the identity provider.
+
+## Build
 
 ```shell
-$ asdf install
-$ bun install
-$ bun start
+$ go build -o auth .
 ```
+
+## Run
+
+Required environment variables:
+
+| Variable | Description |
+|---|---|
+| `SQL_URL` | PostgreSQL connection string |
+| `OAUTH2_CLIENT_ID` | Google OAuth app client ID |
+| `OAUTH2_CLIENT_SECRET` | Google OAuth app client secret |
+| `PORT` | Listen port (default: `8080`) |
+
+```shell
+$ ./auth
+```
+
+The schema in [schema.sql](./schema.sql) must be applied to the database before
+the service starts.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/` | Validate the OAuth2 client and redirect to Google |
+| `GET` | `/callback` | Receive Google's code and issue an internal auth code |
+| `POST` | `/token` | Exchange client credentials + code for a user token |
+| `POST` | `/revoke` | Revoke a user token |
 
 ## Deployment
 
-```shell
-$ bun run deploy
-```
-
-## Diagram
-
-![Diagram](./diagram.svg)
+The provided [Dockerfile](./Dockerfile) builds a `gcr.io/distroless/static`
+image. CI pushes to `registry.moonrhythm.io/deploys-app/auth:<git-sha>`.

--- a/handler.go
+++ b/handler.go
@@ -1,4 +1,4 @@
-package auth
+package main
 
 import (
 	"encoding/base64"

--- a/main.go
+++ b/main.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/acoshift/pgsql/pgctx"
 	_ "github.com/lib/pq"
-
-	"github.com/deploys-app/auth"
 )
 
 func main() {
@@ -33,14 +31,14 @@ func main() {
 	defer db.Close()
 
 	mux := http.NewServeMux()
-	mux.Handle("GET /", auth.RedirectHandler{OAuth2ClientID: oauth2ClientID})
-	mux.Handle("GET /callback", auth.CallbackHandler{
+	mux.Handle("GET /", RedirectHandler{OAuth2ClientID: oauth2ClientID})
+	mux.Handle("GET /callback", CallbackHandler{
 		OAuth2ClientID:     oauth2ClientID,
 		OAuth2ClientSecret: oauth2ClientSecret,
 	})
-	mux.Handle("GET /revoke", auth.RevokeHandler{}) // TODO: remove ?
-	mux.Handle("POST /revoke", auth.RevokePostHandler{})
-	mux.Handle("POST /token", auth.TokenHandler{})
+	mux.Handle("GET /revoke", RevokeHandler{}) // TODO: remove ?
+	mux.Handle("POST /revoke", RevokePostHandler{})
+	mux.Handle("POST /token", TokenHandler{})
 
 	http.ListenAndServe(":"+port, pgctx.Middleware(db)(mux))
 }

--- a/oauth2.go
+++ b/oauth2.go
@@ -1,4 +1,4 @@
-package auth
+package main
 
 import (
 	"context"

--- a/token.go
+++ b/token.go
@@ -1,4 +1,4 @@
-package auth
+package main
 
 import (
 	"context"


### PR DESCRIPTION
## Summary
- Move `cmd/auth/main.go` to `main.go` at the repo root and switch `handler.go`/`oauth2.go`/`token.go` from `package auth` to `package main`. The `auth` package had no external consumers, so the extra layer was overhead.
- Update `Dockerfile` build target from `./cmd/auth` to `.`.
- Rewrite `README.md` to document the actual Go build, required env vars, HTTP endpoints, and Docker/CI deployment path (the previous file referenced bun/asdf and didn't match the code).
- Update `CLAUDE.md` to reflect the flattened layout.

## Test plan
- [x] `go build -o auth .`
- [x] `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)