### PR TITLE
ci: install kubectl in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,6 +18,7 @@ jobs:
         project_id: ${{ vars.GKE_PROJECT }}
         cluster_name: ${{ vars.GKE_CLUSTER }}
         location: ${{ vars.GKE_LOCATION }}
+    - uses: azure/setup-kubectl@v4
     - name: Deploy
       env:
         IMAGE: asia-southeast1-docker.pkg.dev/deploys-app/internal/auth:${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
## Summary
- Add `azure/setup-kubectl@v4` to the deploy workflow so the `kubectl set image` step has a kubectl binary available.

## Why
`google-github-actions/get-gke-credentials@v2` only writes the kubeconfig — it no longer installs kubectl — so the Deploy step needs to install it explicitly.

## Test plan
- [ ] Next deploy run on `main` succeeds and reaches the `kubectl set image` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)