### PR TITLE
feat(auth): use prompt=select_account for Google sign-in

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -126,7 +126,11 @@ func (h RedirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	params.Set("redirect_uri", h.BaseURL+"/callback")
 	params.Set("scope", "https://www.googleapis.com/auth/userinfo.email")
 	params.Set("access_type", "online")
-	params.Set("prompt", "consent")
+	// select_account shows Google's account chooser but skips the consent screen
+	// for users who already granted access — one screen on returning logins
+	// instead of two. We only read the email scope with access_type=online, so we
+	// never needed the forced re-consent that prompt=consent implies.
+	params.Set("prompt", "select_account")
 	params.Set("state", state)
 
 	target := "https://accounts.google.com/o/oauth2/auth?" + params.Encode()

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -52,6 +52,9 @@ func TestRedirectHandler_Confidential_Success(t *testing.T) {
 	if !strings.Contains(loc, url.QueryEscape("https://auth.test/callback")) {
 		t.Errorf("Location missing callback redirect_uri: %q", loc)
 	}
+	if !strings.Contains(loc, "prompt=select_account") {
+		t.Errorf("Location missing prompt=select_account (avoids the extra consent screen): %q", loc)
+	}
 	if c := findCookie(rec, "s"); c == nil || c.Value == "" {
 		t.Error("session cookie 's' not set")
 	}


### PR DESCRIPTION
## What

Change the Google authorize URL in `RedirectHandler` from `prompt=consent` to **`prompt=select_account`**.

`prompt=consent` forces Google's **consent screen on every login** — a second screen returning users must click through even though they already granted access. `prompt=select_account` shows just the account chooser and skips re-consent when access was already granted, so a returning login is **one screen instead of two**.

We only request the `userinfo.email` scope with `access_type=online`, so the forced re-consent that `consent` implies was never needed.

## Changes

- `handler.go`: `prompt=consent` → `prompt=select_account` (+ a comment on why).
- `redirect_test.go`: assert the authorize URL carries `prompt=select_account` so this doesn't silently regress.

`gofmt`/`go vet`/`go build` clean; `go test -run TestRedirectHandler` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)