### PR TITLE
feat(auth): regexp redirect_uris, drop legacy redirect_uri, no DCR patterns

### DIFF
--- a/callback_test.go
+++ b/callback_test.go
@@ -44,7 +44,7 @@ func TestCallbackHandler_Confidential_Success(t *testing.T) {
 
 	tdb := newTestDB(t)
 	ctx := tdb.Ctx()
-	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/*")
+	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/cb")
 	seedSession(t, ctx, "sess123", "web", "gstate", "cbstate", "https://app.example.com/cb", "", "", "")
 
 	q := url.Values{"state": {"gstate"}, "code": {t.Name()}}

--- a/handler.go
+++ b/handler.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 
 	"github.com/acoshift/pgsql/pgctx"
@@ -64,9 +63,8 @@ func (h RedirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Public clients (CLI / MCP) must use PKCE.
 	if oauth2Client.IsPublic() {
-		// Public clients (CLI / MCP) must use PKCE and an exact, pre-registered
-		// redirect URI (loopback port is allowed to vary).
 		if codeChallenge == "" {
 			http.Error(w, "Missing code_challenge parameter", http.StatusBadRequest)
 			return
@@ -75,22 +73,15 @@ func (h RedirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Unsupported code_challenge_method parameter", http.StatusBadRequest)
 			return
 		}
-		if !redirectURIAllowed(oauth2Client.RedirectURIs, callbackURL) {
-			slog.WarnContext(ctx, "redirect: invalid redirect_uri", "client_id", clientID, "redirect_uri", callbackURL)
-			http.Error(w, "Invalid redirect_uri parameter", http.StatusBadRequest)
-			return
-		}
-	} else {
-		pattern := oauth2Client.RedirectURI
-		pattern = strings.ReplaceAll(pattern, ".", `\.`)
-		pattern = strings.ReplaceAll(pattern, "/", `\/`)
-		pattern = strings.ReplaceAll(pattern, "*", `.*`)
-		re := regexp.MustCompile(`^` + pattern + `$`)
-		if !re.MatchString(callbackURL) {
-			slog.WarnContext(ctx, "redirect: invalid redirect_uri", "client_id", clientID, "redirect_uri", callbackURL)
-			http.Error(w, "Invalid redirect_uri parameter", http.StatusBadRequest)
-			return
-		}
+	}
+
+	// The redirect URI must match one of the client's registered redirect_uris —
+	// an exact URI, or an operator-provisioned "regexp:" pattern. Applies to every
+	// client type now that the legacy single-pattern redirect_uri column is gone.
+	if !redirectURIAllowed(oauth2Client.RedirectURIs, callbackURL) {
+		slog.WarnContext(ctx, "redirect: invalid redirect_uri", "client_id", clientID, "redirect_uri", callbackURL)
+		http.Error(w, "Invalid redirect_uri parameter", http.StatusBadRequest)
+		return
 	}
 
 	state := generateState()

--- a/oauth2.go
+++ b/oauth2.go
@@ -18,8 +18,7 @@ var (
 type OAuth2Client struct {
 	ID                      string
 	Secret                  string
-	RedirectURI             string   // legacy glob pattern (confidential clients)
-	RedirectURIs            []string // exact URIs (public / DCR clients)
+	RedirectURIs            []string // exact URIs, or "regexp:" patterns (operator-provisioned only)
 	TokenEndpointAuthMethod string   // "client_secret_post" or "none"
 	ClientName              string
 }
@@ -51,11 +50,11 @@ func getOAuth2Client(ctx context.Context, clientID string) (*OAuth2Client, error
 	var x OAuth2Client
 	var secret sql.NullString
 	err := pgctx.QueryRow(ctx, `
-		select id, secret, redirect_uri, redirect_uris, token_endpoint_auth_method
+		select id, secret, redirect_uris, token_endpoint_auth_method
 		from oauth2_clients
 		where id = $1
 	`, clientID).Scan(
-		&x.ID, &secret, &x.RedirectURI, &x.RedirectURIs, &x.TokenEndpointAuthMethod,
+		&x.ID, &secret, &x.RedirectURIs, &x.TokenEndpointAuthMethod,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrOAuth2ClientNotFound
@@ -70,8 +69,8 @@ func getOAuth2Client(ctx context.Context, clientID string) (*OAuth2Client, error
 // insertOAuth2Client persists a dynamically registered public client.
 func insertOAuth2Client(ctx context.Context, c *OAuth2Client) error {
 	_, err := pgctx.Exec(ctx, `
-		insert into oauth2_clients (id, secret, redirect_uri, redirect_uris, token_endpoint_auth_method, client_name)
-		values ($1, null, '', $2, $3, $4)
+		insert into oauth2_clients (id, secret, redirect_uris, token_endpoint_auth_method, client_name)
+		values ($1, null, $2, $3, $4)
 	`, c.ID, pq.Array(c.RedirectURIs), c.TokenEndpointAuthMethod, c.ClientName)
 	return err
 }

--- a/pkce.go
+++ b/pkce.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"encoding/base64"
 	"net/url"
+	"regexp"
 	"strings"
 )
 
@@ -26,9 +27,16 @@ func isLoopbackHost(host string) bool {
 	return host == "127.0.0.1" || host == "::1" || host == "localhost"
 }
 
-// redirectURIAllowed reports whether got matches one of the registered exact
-// redirect URIs. Per RFC 8252 the port is ignored for loopback addresses, so a
-// CLI listening on an ephemeral localhost port is accepted.
+// redirectRegexpPrefix marks a redirect_uris entry as a pattern rather than an
+// exact URI. Such entries are operator-provisioned only — DCR rejects them (see
+// validRegistrationRedirectURI) — so a self-registered client can never widen
+// its own redirect matching.
+const redirectRegexpPrefix = "regexp:"
+
+// redirectURIAllowed reports whether got matches one of the client's registered
+// redirect URIs. An entry is matched exactly (scheme + host + path; the port may
+// vary for loopback per RFC 8252) unless it carries the "regexp:" prefix, in
+// which case the remainder is a pattern (see matchRedirectPattern).
 func redirectURIAllowed(registered []string, got string) bool {
 	gu, err := url.Parse(got)
 	if err != nil {
@@ -37,6 +45,12 @@ func redirectURIAllowed(registered []string, got string) bool {
 	for _, raw := range registered {
 		raw = strings.TrimSpace(raw)
 		if raw == "" {
+			continue
+		}
+		if pattern, ok := strings.CutPrefix(raw, redirectRegexpPrefix); ok {
+			if matchRedirectPattern(pattern, got) {
+				return true
+			}
 			continue
 		}
 		ru, err := url.Parse(raw)
@@ -62,9 +76,37 @@ func redirectURIAllowed(registered []string, got string) bool {
 	return false
 }
 
+// matchRedirectPattern matches got against an operator-provisioned redirect
+// pattern using the deploys glob dialect: literal '.' and '/' are escaped, '*'
+// expands to '.*', and any other regex metacharacters (e.g. \d+) are honoured.
+// The pattern is anchored ^...$ against the whole redirect URI, so it cannot
+// match a broader host than written. A malformed pattern denies (never panics);
+// Go's RE2 engine guarantees linear-time matching (no ReDoS).
+//
+// Matching is case-sensitive (unlike the host-only EqualFold of the exact path),
+// so write the host in lowercase — the authority of an inbound redirect URI is
+// already lowercase (browsers normalise it; generated preview hosts are
+// lowercase). Being case-sensitive only ever denies, never widens.
+func matchRedirectPattern(pattern, got string) bool {
+	p := strings.ReplaceAll(pattern, ".", `\.`)
+	p = strings.ReplaceAll(p, "/", `\/`)
+	p = strings.ReplaceAll(p, "*", `.*`)
+	re, err := regexp.Compile(`^` + p + `$`)
+	if err != nil {
+		return false
+	}
+	return re.MatchString(got)
+}
+
 // validRegistrationRedirectURI enforces the redirect URIs a client may register:
 // HTTPS anywhere, or plain HTTP only for loopback (native/CLI clients).
 func validRegistrationRedirectURI(s string) bool {
+	// "regexp:" patterns are operator-provisioned only: a dynamically registered
+	// (DCR) client may register exact URIs but never a pattern, which could match
+	// hosts it does not control.
+	if strings.HasPrefix(s, redirectRegexpPrefix) {
+		return false
+	}
 	u, err := url.Parse(s)
 	if err != nil || u.Host == "" {
 		return false

--- a/pkce_test.go
+++ b/pkce_test.go
@@ -59,6 +59,17 @@ func TestRedirectURIAllowed(t *testing.T) {
 		{"host mismatch", []string{"https://app.example.com/cb"}, "https://evil.example.com/cb", false},
 		{"not in list", []string{"https://a.example.com/cb"}, "https://b.example.com/cb", false},
 		{"matches second entry", []string{"https://a.example.com/cb", "http://127.0.0.1:1/cb"}, "http://127.0.0.1:42/cb", true},
+
+		// "regexp:" patterns (operator-provisioned). The PR-preview use case: a
+		// bounded pattern, NOT an all-subdomain wildcard.
+		{"regexp digit match", []string{`regexp:https://console-pr-\d+-606515731026706458.rcf2.deploys.app/auth/callback`}, "https://console-pr-42-606515731026706458.rcf2.deploys.app/auth/callback", true},
+		{"regexp rejects non-digit", []string{`regexp:https://console-pr-\d+-606515731026706458.rcf2.deploys.app/auth/callback`}, "https://console-pr-abc-606515731026706458.rcf2.deploys.app/auth/callback", false},
+		{"regexp dot is literal", []string{`regexp:https://console-pr-\d+-606515731026706458.rcf2.deploys.app/auth/callback`}, "https://console-pr-42-606515731026706458Xrcf2.deploys.app/auth/callback", false},
+		{"regexp rejects arbitrary subdomain", []string{`regexp:https://console-pr-\d+-606515731026706458.rcf2.deploys.app/auth/callback`}, "https://evil.rcf2.deploys.app/auth/callback", false},
+		{"regexp star wildcard", []string{`regexp:https://app.example.com/*`}, "https://app.example.com/deep/cb", true},
+		{"regexp anchored at end", []string{`regexp:https://app.example.com/cb`}, "https://app.example.com/cb/extra", false},
+		{"regexp anchored at start", []string{`regexp:https://app.example.com/cb`}, "evil-https://app.example.com/cb", false},
+		{"exact and regexp entries together", []string{"https://a.example.com/cb", `regexp:https://console-pr-\d+-606515731026706458.rcf2.deploys.app/auth/callback`}, "https://console-pr-7-606515731026706458.rcf2.deploys.app/auth/callback", true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -78,6 +89,9 @@ func TestValidRegistrationRedirectURI(t *testing.T) {
 		"ftp://example.com":          false,
 		"not-a-url":                  false,
 		"":                           false,
+		// DCR must never let a client self-register a "regexp:" pattern.
+		`regexp:https://app.example.com/*`:  false,
+		`regexp:https://console-pr-\d+.com`: false,
 	} {
 		if got := validRegistrationRedirectURI(uri); got != want {
 			t.Errorf("validRegistrationRedirectURI(%q) = %v, want %v", uri, got, want)

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -28,7 +28,7 @@ func TestRedirectHandler_Confidential_Success(t *testing.T) {
 	t.Parallel()
 	tdb := newTestDB(t)
 	ctx := tdb.Ctx()
-	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/*")
+	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/cb")
 
 	q := url.Values{
 		"client_id":    {"web"},
@@ -101,7 +101,7 @@ func TestRedirectHandler_Confidential_RedirectNotAllowed(t *testing.T) {
 	t.Parallel()
 	tdb := newTestDB(t)
 	ctx := tdb.Ctx()
-	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/*")
+	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/cb")
 
 	q := url.Values{"client_id": {"web"}, "state": {"s"}, "redirect_uri": {"https://evil.example.com/cb"}}
 	rec := httptest.NewRecorder()
@@ -109,6 +109,39 @@ func TestRedirectHandler_Confidential_RedirectNotAllowed(t *testing.T) {
 		ServeHTTP(rec, getReq(t, q).WithContext(ctx))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestRedirectHandler_RegexpRedirect exercises an operator-provisioned "regexp:"
+// redirect_uris entry end to end (the PR-preview use case): a bounded pattern
+// that matches dynamic preview hosts but not arbitrary subdomains.
+func TestRedirectHandler_RegexpRedirect(t *testing.T) {
+	t.Parallel()
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx()
+	seedConfidentialClient(t, ctx, "preview", "topsecret",
+		`regexp:https://console-pr-\d+-606515731026706458.rcf2.deploys.app/auth/callback`)
+
+	cases := map[string]struct {
+		redirect string
+		want     int
+	}{
+		"matching preview host":   {"https://console-pr-42-606515731026706458.rcf2.deploys.app/auth/callback", http.StatusFound},
+		"non-digit pr id":         {"https://console-pr-abc-606515731026706458.rcf2.deploys.app/auth/callback", http.StatusBadRequest},
+		"different account zone":  {"https://console-pr-42-999999999999999999.rcf2.deploys.app/auth/callback", http.StatusBadRequest},
+		"arbitrary subdomain":     {"https://evil.rcf2.deploys.app/auth/callback", http.StatusBadRequest},
+		"dot is literal not wild": {"https://console-pr-42-606515731026706458Xrcf2.deploys.app/auth/callback", http.StatusBadRequest},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			q := url.Values{"client_id": {"preview"}, "state": {"s"}, "redirect_uri": {c.redirect}}
+			rec := httptest.NewRecorder()
+			RedirectHandler{OAuth2ClientID: "g", BaseURL: "https://auth.test"}.
+				ServeHTTP(rec, getReq(t, q).WithContext(ctx))
+			if rec.Code != c.want {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, c.want, rec.Body.String())
+			}
+		})
 	}
 }
 

--- a/register_test.go
+++ b/register_test.go
@@ -71,10 +71,11 @@ func TestRegisterHandler_Rejections(t *testing.T) {
 	t.Parallel()
 	// All rejected before any DB write, so no test DB is needed.
 	cases := map[string]string{
-		"invalid json":          `{not json`,
-		"no redirect_uris":      `{"client_name":"x"}`,
-		"non-loopback http":     `{"redirect_uris":["http://app.example.com/cb"]}`,
-		"confidential rejected": `{"redirect_uris":["https://app.example.com/cb"],"token_endpoint_auth_method":"client_secret_post"}`,
+		"invalid json":            `{not json`,
+		"no redirect_uris":        `{"client_name":"x"}`,
+		"non-loopback http":       `{"redirect_uris":["http://app.example.com/cb"]}`,
+		"confidential rejected":   `{"redirect_uris":["https://app.example.com/cb"],"token_endpoint_auth_method":"client_secret_post"}`,
+		"regexp pattern rejected": `{"redirect_uris":["regexp:https://*.example.com/cb"]}`,
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/schema/03_redirect_uris_only.sql
+++ b/schema/03_redirect_uris_only.sql
@@ -1,0 +1,22 @@
+-- Consolidate redirect-URI matching onto redirect_uris and drop the legacy
+-- single-value redirect_uri column.
+--
+-- Backfill first so existing (confidential) clients keep working: a value
+-- containing a glob '*' becomes a "regexp:" entry — the matcher applies the same
+-- escape-dots / '*'->'.*' dialect the old column used, so behaviour is preserved
+-- and patterns like console-pr-\d+-<id>.rcf2.deploys.app are honoured — while an
+-- exact value is copied verbatim. Public / DCR clients already use redirect_uris
+-- (their redirect_uri is '') and are skipped. The row backfill is idempotent.
+update oauth2_clients
+set redirect_uris = array_append(
+		redirect_uris,
+		case when position('*' in redirect_uri) > 0
+			then 'regexp:' || redirect_uri
+			else redirect_uri
+		end
+	)
+where redirect_uri <> ''
+	and not (redirect_uri = any(redirect_uris))
+	and not (('regexp:' || redirect_uri) = any(redirect_uris));
+
+alter table oauth2_clients drop column redirect_uri;

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -28,12 +28,12 @@ func fakeIDToken(email string) string {
 
 // --- seeding helpers (operate on a context already carrying the DB) ---
 
-func seedConfidentialClient(t *testing.T, ctx context.Context, id, secret, redirectGlob string) {
+func seedConfidentialClient(t *testing.T, ctx context.Context, id, secret string, redirectURIs ...string) {
 	t.Helper()
 	_, err := pgctx.Exec(ctx, `
-		insert into oauth2_clients (id, secret, redirect_uri, token_endpoint_auth_method)
+		insert into oauth2_clients (id, secret, redirect_uris, token_endpoint_auth_method)
 		values ($1, $2, $3, 'client_secret_post')
-	`, id, secret, redirectGlob)
+	`, id, secret, pq.Array(redirectURIs))
 	if err != nil {
 		t.Fatalf("seed confidential client: %v", err)
 	}

--- a/token_test.go
+++ b/token_test.go
@@ -22,7 +22,7 @@ func TestTokenHandler_Confidential_Success(t *testing.T) {
 	t.Parallel()
 	tdb := newTestDB(t)
 	ctx := tdb.Ctx()
-	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/*")
+	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/cb")
 	seedCode(t, ctx, "abc", "web", "user@example.com", "", "", "https://app.example.com/cb", "")
 
 	form := url.Values{"client_id": {"web"}, "client_secret": {"topsecret"}, "code": {"abc"}}
@@ -68,7 +68,7 @@ func TestTokenHandler_Confidential_WrongSecret(t *testing.T) {
 	t.Parallel()
 	tdb := newTestDB(t)
 	ctx := tdb.Ctx()
-	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/*")
+	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/cb")
 	seedCode(t, ctx, "abc", "web", "user@example.com", "", "", "https://app.example.com/cb", "")
 
 	form := url.Values{"client_id": {"web"}, "client_secret": {"wrong"}, "code": {"abc"}}
@@ -89,7 +89,7 @@ func TestTokenHandler_Confidential_MissingSecret(t *testing.T) {
 	t.Parallel()
 	tdb := newTestDB(t)
 	ctx := tdb.Ctx()
-	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/*")
+	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/cb")
 
 	form := url.Values{"client_id": {"web"}, "code": {"abc"}}
 	rec := httptest.NewRecorder()
@@ -253,7 +253,7 @@ func TestTokenHandler_InvalidCode(t *testing.T) {
 	t.Parallel()
 	tdb := newTestDB(t)
 	ctx := tdb.Ctx()
-	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/*")
+	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/cb")
 
 	form := url.Values{"client_id": {"web"}, "client_secret": {"topsecret"}, "code": {"gone"}}
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
Implements the three requested changes to redirect-URI validation.

## 1. Bounded `regexp:` patterns in `redirect_uris`

An entry prefixed `regexp:` is matched as a pattern (the same dialect the old `redirect_uri` column used: literal `.`/`/` escaped, `*`→`.*`, other regex like `\d+` honoured, anchored `^…$`). So an operator can register, for a PR-preview client:

```
regexp:https://console-pr-\d+-606515731026706458.rcf2.deploys.app/auth/callback
```

This matches `console-pr-42-…` and rejects `console-pr-abc-…`, a different account zone, an arbitrary `*.rcf2.deploys.app` subdomain, and (dots are literal) `…606515731026706458Xrcf2…`. Compiled with `regexp.Compile` — a malformed pattern denies (never panics), and Go's RE2 engine is linear-time (no ReDoS).

## 2. Removed the legacy singular `redirect_uri`

`RedirectHandler` now validates **every** client type (public + confidential) through `redirectURIAllowed(redirect_uris)`; public clients still require PKCE. The `OAuth2Client.RedirectURI` field and the column references are gone.

Migration `schema/03_redirect_uris_only.sql` backfills the old `redirect_uri` into `redirect_uris` (a glob becomes a `regexp:` entry so existing behaviour is preserved; an exact value is copied verbatim; public/DCR clients are skipped) and then drops the column. The per-code redirect binding (`oauth2_codes.redirect_uri`, used at `/token` for public clients) is unchanged.

## 3. DCR cannot register patterns

`validRegistrationRedirectURI` rejects any `regexp:`-prefixed entry, so a dynamically registered (`POST /register`) client can only use exact URIs and can never widen its own redirect matching. Patterns are operator-provisioned only.

## ⚠️ Operator action

Apply `schema/03_redirect_uris_only.sql` to the prod DB — `main.go` does not auto-migrate (same as the existing `02_mcp.sql`).

## Tests / review

- New pure-unit cases (digit match, dot-is-literal, arbitrary-subdomain reject, anchoring, `*` wildcard, DCR rejection) + an end-to-end `RedirectHandler` regexp test + a `/register` rejection test. **79 tests pass**; gofmt/vet/build clean.
- Adversarial security review (open-redirect / ReDoS / DCR-bypass / migration lenses): **go**, no blockers. Nits noted (regexp match is case-sensitive — documented; inbound hosts are always lowercase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)