### PR TITLE
schema: add scope columns to user_tokens

### DIFF
--- a/schema/01_init.sql
+++ b/schema/01_init.sql
@@ -28,9 +28,11 @@ create table oauth2_sessions (
 create index oauth2_sessions_created_at_idx on oauth2_sessions (created_at);
 
 create table user_tokens (
-	token      string,
-	email      string      not null,
-	expires_at timestamptz not null,
-	created_at timestamptz not null default now(),
+	token             string,
+	email             string      not null,
+	expires_at        timestamptz not null,
+	created_at        timestamptz not null default now(),
+	scope_project_id  int,
+	scope_permissions string[],
 	primary key (token)
 );


### PR DESCRIPTION
Keeps the shared `user_tokens` table definition in sync with the apiserver, which now mints **attenuated tokens** (`me.generateToken`, deploys-app/apiserver#140) carrying a project + permission scope.

The auth service itself doesn't read or write these columns — they're nullable, so `/token` keeps issuing unscoped full tokens unchanged, and introspect is untouched. This is purely the fresh-DB schema staying consistent across the two services that share the table.

## Schema migration

```sql
alter table user_tokens add column if not exists scope_project_id int;
alter table user_tokens add column if not exists scope_permissions string[];
```

`go build` + `go test ./...` pass (schema applies cleanly to the test CockroachDB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)