### PR TITLE
chore: replace test contains() helper with slices.Contains

### DIFF
--- a/handler_helpers_test.go
+++ b/handler_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 )
 
@@ -83,20 +84,11 @@ func TestMetadataHandler(t *testing.T) {
 	if meta.RegistrationEndpoint != "https://auth.test/register" {
 		t.Errorf("registration_endpoint = %q", meta.RegistrationEndpoint)
 	}
-	if !contains(meta.CodeChallengeMethodsSupported, "S256") {
+	if !slices.Contains(meta.CodeChallengeMethodsSupported, "S256") {
 		t.Errorf("code_challenge_methods_supported = %v, want S256", meta.CodeChallengeMethodsSupported)
 	}
-	if !contains(meta.TokenEndpointAuthMethodsSupported, "none") ||
-		!contains(meta.TokenEndpointAuthMethodsSupported, "client_secret_post") {
+	if !slices.Contains(meta.TokenEndpointAuthMethodsSupported, "none") ||
+		!slices.Contains(meta.TokenEndpointAuthMethodsSupported, "client_secret_post") {
 		t.Errorf("token_endpoint_auth_methods_supported = %v", meta.TokenEndpointAuthMethodsSupported)
 	}
-}
-
-func contains(s []string, v string) bool {
-	for _, x := range s {
-		if x == v {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## What

Go modernization for the `auth` package.

### Changes
- Replace the test-only `contains()` linear-search helper with direct `slices.Contains` calls at its three call sites in `TestMetadataHandler`, and remove the wrapper (Go 1.21)

### Safety
- **No functional change** (test-only helper).
- `go build`, `go vet`, and `go test ./...` all pass (handler tests run against the CockroachDB test server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)