### PR TITLE
fix(introspect): refuse to resolve scoped tokens to a bare identity

### DIFF
--- a/introspect_test.go
+++ b/introspect_test.go
@@ -107,6 +107,33 @@ func TestIntrospectHandler_ExpiredToken(t *testing.T) {
 	}
 }
 
+func TestIntrospectHandler_ScopedTokenInactive(t *testing.T) {
+	t.Parallel()
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx()
+	const raw = "deploys-api.scoped"
+	// A scoped token (non-null scope_project_id) is a narrowly-attenuated agent
+	// credential. Introspection drops the scope, so it must read as inactive —
+	// resolving it to its bare owner would promote it to the minter's full
+	// authority (a confused deputy).
+	if _, err := pgctxExec(t, ctx, `
+		insert into user_tokens (token, email, expires_at, scope_project_id, scope_permissions)
+		values ($1, $2, now() + interval '1 hour', $3, '{deployment.get}')
+	`, hashToken(raw), "agent@example.com", 42); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	IntrospectHandler{Token: "secret"}.ServeHTTP(rec, introspectReq(t, "Bearer secret", raw).WithContext(ctx))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if active := decodeActive(t, rec); active {
+		t.Error("active = true, want false for scoped token")
+	}
+}
+
 func TestIntrospectHandler_EmptyToken(t *testing.T) {
 	t.Parallel()
 	// Empty token short-circuits before any DB lookup.

--- a/token.go
+++ b/token.go
@@ -65,12 +65,22 @@ func deleteToken(ctx context.Context, token string) error {
 }
 
 // lookupToken resolves a hashed token to its owner email and expiry (unix
-// seconds), returning sql.ErrNoRows when the token is unknown or expired.
+// seconds), returning sql.ErrNoRows when the token is unknown, expired, or
+// scoped.
+//
+// Scoped tokens (a non-null scope_project_id, minted by me.generateToken) are
+// deliberately excluded: introspection returns only the bare identity (sub),
+// dropping the token's attenuation, so any resource server that trusts that sub
+// would silently promote a narrowly-scoped agent token to its minter's full
+// authority — a confused deputy. A scoped token is enforced ≤-minter only where
+// its scope is re-evaluated (the apiserver Bearer path), so it must never
+// resolve to a bare identity here. It therefore reads as inactive, exactly like
+// an unknown token; the agent presents it directly to the apiserver instead.
 func lookupToken(ctx context.Context, hashedToken string) (email string, exp int64, err error) {
 	err = pgctx.QueryRow(ctx, `
 		select email, extract(epoch from expires_at)::bigint
 		from user_tokens
-		where token = $1 and expires_at > now()
+		where token = $1 and expires_at > now() and scope_project_id is null
 	`, hashedToken).Scan(&email, &exp)
 	return
 }


### PR DESCRIPTION
**PR0 / security prerequisite of SPEC-agent-identity (A5).**

`lookupToken` now filters `scope_project_id is null`, so `POST /introspect` reports a `me.generateToken` **scoped token** as `{"active": false}` instead of resolving it to its minter's bare `sub`.

## Why
Introspection (RFC 7662) returns only `sub`/`exp` — it **drops the token's scope**. A scoped token is enforced ≤-minter only where its attenuation is re-evaluated (the apiserver Bearer path). If a resource server introspected a scoped token and trusted the `sub`, it would silently treat a narrowly-scoped agent credential as the minter's full identity — a confused deputy. Today's blast radius is small (scoped tokens carry few weak perms), but A5 widens what a scoped token may carry, so this gate must land first.

## Scope
- One predicate added to `lookupToken`; a scoped token now reads as inactive, exactly like an unknown/expired one. Agents present scoped tokens directly to the apiserver (scope-aware) instead.
- No schema change — `scope_project_id` already exists in `user_tokens`.
- New test `TestIntrospectHandler_ScopedTokenInactive`; existing active/expired/unknown tests unchanged.

**Deploy this before the apiserver PR (deploys-app/apiserver#199)** that widens scoped-token delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9FhPEapaKr4VugQBEdisj