### PR TITLE
feat: bound DCR clients (seed CLI client, idle GC, rate-limit /register)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ the authorize and token endpoints, and may use loopback redirect URIs
 `client_secret` as before. A resource server validates issued bearer tokens via
 `/introspect` (authenticated with `INTROSPECTION_TOKEN`).
 
+`/register` mints a permanent public-client row, so it is **rate-limited per
+source IP** and dynamically-registered clients are **garbage-collected when idle**
+(reaped after 90 days with no authorize; `last_used_at` is stamped on every
+authorize, so a reused client never expires). Operator-seeded and confidential
+clients are never reaped. The deploys CLI ships a baked-in `deploys-cli` public
+client (seeded by `schema/05_seed_cli_client.sql`) so ordinary CLI logins skip
+`/register` entirely.
+
 ## Deployment
 
 The provided [Dockerfile](./Dockerfile) builds a `gcr.io/distroless/static`

--- a/cleanup.go
+++ b/cleanup.go
@@ -7,10 +7,18 @@ import (
 	"time"
 )
 
-// startCleanupWorker periodically removes expired oauth2 sessions and codes.
-// Both have a 1-hour TTL but are only deleted on use, so abandoned rows would
-// otherwise accumulate. Registered clients are never reaped — MCP clients reuse
-// their client_id across logins.
+// clientIdleTTL is how long a dynamically-registered (DCR) public client may go
+// unused before it is reaped. Idle, not age: an actively-reused client (the
+// CLI/MCP reuse one client_id) is touched at every authorize and so never
+// expires. Generous, so a client idle between releases survives.
+const clientIdleTTL = 90 * 24 * time.Hour
+
+// startCleanupWorker periodically removes expired oauth2 sessions and codes, and
+// reaps abandoned dynamically-registered clients. Sessions and codes have a
+// 1-hour TTL but are only deleted on use, so abandoned rows would otherwise
+// accumulate. DCR clients are reaped only when idle past clientIdleTTL; reused
+// clients (touched at authorize) and all non-DCR clients — the Google web
+// client, operator-seeded public clients like deploys-cli — are never reaped.
 func startCleanupWorker(db *sql.DB) {
 	go func() {
 		for {
@@ -29,5 +37,17 @@ func cleanupExpired(db *sql.DB) {
 		if _, err := db.ExecContext(ctx, q); err != nil {
 			slog.ErrorContext(ctx, "cleanup: delete expired rows", "error", err)
 		}
+	}
+
+	// Reap DCR clients idle past the TTL. coalesce(last_used_at, created_at) ages
+	// a registered-but-never-used row from its creation. dynamically_registered =
+	// false rows (Google web, operator-seeded) are never matched.
+	cutoff := time.Now().Add(-clientIdleTTL)
+	if _, err := db.ExecContext(ctx, `
+		delete from oauth2_clients
+		where dynamically_registered = true
+		  and coalesce(last_used_at, created_at) < $1
+	`, cutoff); err != nil {
+		slog.ErrorContext(ctx, "cleanup: delete idle clients", "error", err)
 	}
 }

--- a/client_lifecycle_test.go
+++ b/client_lifecycle_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/acoshift/pgsql/pgctx"
+)
+
+// clientFlags reads the lifecycle columns of a client row.
+func clientFlags(t *testing.T, ctx context.Context, id string) (dyn bool, lastUsed sql.NullTime, ok bool) {
+	t.Helper()
+	err := pgctx.QueryRow(ctx,
+		`select dynamically_registered, last_used_at from oauth2_clients where id = $1`, id,
+	).Scan(&dyn, &lastUsed)
+	if err != nil {
+		return false, sql.NullTime{}, false
+	}
+	return dyn, lastUsed, true
+}
+
+func clientExists(t *testing.T, ctx context.Context, id string) bool {
+	t.Helper()
+	var n int
+	if err := pgctx.QueryRow(ctx, `select count(*) from oauth2_clients where id = $1`, id).Scan(&n); err != nil {
+		t.Fatalf("count client %q: %v", id, err)
+	}
+	return n > 0
+}
+
+// The migration seeds the well-known public CLI client as a non-DCR row.
+func TestSeedCLIClientPresent(t *testing.T) {
+	t.Parallel()
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx()
+
+	if !clientExists(t, ctx, "deploys-cli") {
+		t.Fatal("deploys-cli client was not seeded by the migration")
+	}
+	dyn, _, ok := clientFlags(t, ctx, "deploys-cli")
+	if !ok {
+		t.Fatal("deploys-cli flags not readable")
+	}
+	if dyn {
+		t.Error("seeded deploys-cli must NOT be dynamically_registered (would make it GC-eligible)")
+	}
+	uris, ok := clientRedirectURIs(t, ctx, "deploys-cli")
+	if !ok || len(uris) != 1 || uris[0] != "http://127.0.0.1/callback" {
+		t.Errorf("deploys-cli redirect_uris = %v", uris)
+	}
+	// And it must be a public client (PKCE, no secret).
+	var method string
+	if err := pgctx.QueryRow(ctx, `select token_endpoint_auth_method from oauth2_clients where id='deploys-cli'`).Scan(&method); err != nil {
+		t.Fatal(err)
+	}
+	if method != "none" {
+		t.Errorf("deploys-cli auth method = %q; want none", method)
+	}
+}
+
+// A DCR registration is marked dynamically_registered so GC may reap it.
+func TestRegisterMarksDynamicallyRegistered(t *testing.T) {
+	t.Parallel()
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx()
+
+	rec := httptest.NewRecorder()
+	body := `{"client_name":"cli","redirect_uris":["http://127.0.0.1/callback"]}`
+	RegisterHandler{BaseURL: "https://auth.test"}.ServeHTTP(rec, postJSON(t, "/register", body).WithContext(ctx))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		ClientID string `json:"client_id"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	dyn, _, ok := clientFlags(t, ctx, resp.ClientID)
+	if !ok {
+		t.Fatal("registered client not found")
+	}
+	if !dyn {
+		t.Error("DCR client must be marked dynamically_registered")
+	}
+}
+
+// Authorize stamps last_used_at so GC reaps by idle time.
+func TestRedirectStampsLastUsed(t *testing.T) {
+	t.Parallel()
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx()
+
+	// deploys-cli is seeded; its port-less loopback redirect matches any port.
+	_, challenge := pkcePair()
+	q := url.Values{}
+	q.Set("client_id", "deploys-cli")
+	q.Set("state", "cbstate")
+	q.Set("redirect_uri", "http://127.0.0.1:5555/callback")
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/?"+q.Encode(), nil).WithContext(ctx)
+	RedirectHandler{OAuth2ClientID: "google-client", BaseURL: "https://auth.test"}.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("authorize status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	_, lastUsed, ok := clientFlags(t, ctx, "deploys-cli")
+	if !ok {
+		t.Fatal("client not found")
+	}
+	if !lastUsed.Valid {
+		t.Error("authorize did not stamp last_used_at")
+	}
+}
+
+// GC reaps only idle DCR clients; fresh DCR and all non-DCR clients survive.
+func TestCleanupReapsIdleDCRClients(t *testing.T) {
+	t.Parallel()
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx()
+
+	old := time.Now().Add(-100 * 24 * time.Hour)
+	seed := func(id string, dcr bool, lastUsed *time.Time, createdAgo time.Duration) {
+		created := time.Now().Add(-createdAgo)
+		_, err := pgctx.Exec(ctx, `
+			insert into oauth2_clients (id, secret, redirect_uris, token_endpoint_auth_method, client_name, dynamically_registered, created_at, last_used_at)
+			values ($1, null, array['http://127.0.0.1/callback'], 'none', $1, $2, $3, $4)
+		`, id, dcr, created, lastUsed)
+		if err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+	seed("idle-dcr", true, &old, 0) // reaped: idle past TTL
+	now := time.Now()
+	seed("fresh-dcr", true, &now, 0)                    // kept: recently used
+	seed("never-used-dcr", true, nil, 100*24*time.Hour) // reaped: null last_used, old created_at
+	seed("old-seeded", false, &old, 0)                  // kept: not DCR
+
+	cleanupExpired(tdb.DB)
+
+	for _, id := range []string{"fresh-dcr", "old-seeded", "deploys-cli"} {
+		if !clientExists(t, ctx, id) {
+			t.Errorf("client %q should have survived GC", id)
+		}
+	}
+	for _, id := range []string{"idle-dcr", "never-used-dcr"} {
+		if clientExists(t, ctx, id) {
+			t.Errorf("idle DCR client %q should have been reaped", id)
+		}
+	}
+}
+
+func TestRegisterLimiter(t *testing.T) {
+	t.Parallel()
+	// Construct the struct directly to avoid starting the sweep goroutine.
+	l := &registerLimiter{hits: map[string][]time.Time{}, max: 2, window: time.Hour}
+	if !l.allow("1.2.3.4") || !l.allow("1.2.3.4") {
+		t.Fatal("first two hits should be allowed")
+	}
+	if l.allow("1.2.3.4") {
+		t.Error("third hit within window should be denied")
+	}
+	// A different key is independent.
+	if !l.allow("5.6.7.8") {
+		t.Error("a different IP should not be limited")
+	}
+}
+
+func TestClientIP(t *testing.T) {
+	cases := []struct {
+		xff, remote, want string
+	}{
+		{"", "1.2.3.4:55555", "1.2.3.4"},
+		{"9.9.9.9", "1.2.3.4:5", "9.9.9.9"},
+		// Rightmost (proxy-appended) entry wins, not the spoofable leftmost.
+		{"9.9.9.9, 10.0.0.1", "1.2.3.4:5", "10.0.0.1"},
+		{"9.9.9.9 , 10.0.0.1 ", "1.2.3.4:5", "10.0.0.1"},
+	}
+	for _, c := range cases {
+		r := httptest.NewRequest(http.MethodPost, "/register", nil)
+		r.RemoteAddr = c.remote
+		if c.xff != "" {
+			r.Header.Set("X-Forwarded-For", c.xff)
+		}
+		if got := clientIP(r); got != c.want {
+			t.Errorf("clientIP(xff=%q remote=%q) = %q; want %q", c.xff, c.remote, got, c.want)
+		}
+	}
+}

--- a/handler.go
+++ b/handler.go
@@ -84,6 +84,9 @@ func (h RedirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Mark the client as used so idle GC reaps by last use, not creation age.
+	touchClientLastUsed(ctx, oauth2Client.ID)
+
 	state := generateState()
 	sessionID := generateSessionID()
 

--- a/main.go
+++ b/main.go
@@ -5,9 +5,18 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/acoshift/pgsql/pgctx"
 	_ "github.com/lib/pq"
+)
+
+// maxRegistrationsPerWindow caps Dynamic Client Registration per source IP. It
+// is generous for any legitimate caller (the CLI registers at most once and then
+// reuses its cached client_id) while blunting bulk-registration abuse.
+const (
+	maxRegistrationsPerWindow = 20
+	registrationWindow        = time.Hour
 )
 
 func main() {
@@ -52,7 +61,10 @@ func main() {
 	mux.Handle("GET /revoke", RevokeHandler{}) // TODO: remove ?
 	mux.Handle("POST /revoke", RevokePostHandler{})
 	mux.Handle("POST /token", TokenHandler{})
-	mux.Handle("POST /register", RegisterHandler{BaseURL: baseURL})
+	mux.Handle("POST /register", RegisterHandler{
+		BaseURL: baseURL,
+		Limiter: newRegisterLimiter(maxRegistrationsPerWindow, registrationWindow),
+	})
 	mux.Handle("POST /introspect", IntrospectHandler{Token: introspectionToken})
 
 	http.ListenAndServe(":"+port, pgctx.Middleware(db)(mux))

--- a/oauth2.go
+++ b/oauth2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"log/slog"
 
 	"github.com/acoshift/pgsql/pgctx"
 	"github.com/lib/pq"
@@ -66,13 +67,26 @@ func getOAuth2Client(ctx context.Context, clientID string) (*OAuth2Client, error
 	return &x, nil
 }
 
-// insertOAuth2Client persists a dynamically registered public client.
+// insertOAuth2Client persists a dynamically registered public client. It is
+// marked dynamically_registered so the cleanup worker may reap it when idle;
+// operator-seeded and confidential clients are inserted elsewhere and keep the
+// column's default of false (never reaped).
 func insertOAuth2Client(ctx context.Context, c *OAuth2Client) error {
 	_, err := pgctx.Exec(ctx, `
-		insert into oauth2_clients (id, secret, redirect_uris, token_endpoint_auth_method, client_name)
-		values ($1, null, $2, $3, $4)
+		insert into oauth2_clients (id, secret, redirect_uris, token_endpoint_auth_method, client_name, dynamically_registered)
+		values ($1, null, $2, $3, $4, true)
 	`, c.ID, pq.Array(c.RedirectURIs), c.TokenEndpointAuthMethod, c.ClientName)
 	return err
+}
+
+// touchClientLastUsed records that a client was just used (at authorize time),
+// so idle GC reaps by last use rather than creation age. Best-effort: a failure
+// must not break the login, so the error is logged and swallowed.
+func touchClientLastUsed(ctx context.Context, clientID string) {
+	_, err := pgctx.Exec(ctx, `update oauth2_clients set last_used_at = now() where id = $1`, clientID)
+	if err != nil {
+		slog.WarnContext(ctx, "touch client last_used_at", "error", err, "client_id", clientID)
+	}
 }
 
 func insertOAuth2Code(ctx context.Context, clientID, code string, c *OAuth2Code) error {

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// registerLimiter is a small per-IP fixed-window limiter for the unauthenticated
+// /register (Dynamic Client Registration) endpoint. DCR mints a permanent client
+// row, so an unbounded /register is an abuse vector; this caps registrations per
+// source IP per window. It is in-memory and per-instance — defense in depth, not
+// a hard global guarantee — and is the burst control that complements the idle
+// GC (which only bounds steady-state size).
+type registerLimiter struct {
+	mu     sync.Mutex
+	hits   map[string][]time.Time
+	max    int
+	window time.Duration
+}
+
+func newRegisterLimiter(max int, window time.Duration) *registerLimiter {
+	l := &registerLimiter{hits: map[string][]time.Time{}, max: max, window: window}
+	go l.sweepLoop()
+	return l
+}
+
+// allow records a hit for key and reports whether it is within the per-window
+// cap. It also prunes the key's expired hits in place.
+func (l *registerLimiter) allow(key string) bool {
+	now := time.Now()
+	cutoff := now.Add(-l.window)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	recent := l.hits[key][:0]
+	for _, t := range l.hits[key] {
+		if t.After(cutoff) {
+			recent = append(recent, t)
+		}
+	}
+	if len(recent) >= l.max {
+		l.hits[key] = recent
+		return false
+	}
+	l.hits[key] = append(recent, now)
+	return true
+}
+
+// sweepLoop periodically drops keys whose hits have all expired, so the map does
+// not grow without bound across many distinct source IPs.
+func (l *registerLimiter) sweepLoop() {
+	for {
+		time.Sleep(l.window)
+		cutoff := time.Now().Add(-l.window)
+		l.mu.Lock()
+		for k, ts := range l.hits {
+			alive := ts[:0]
+			for _, t := range ts {
+				if t.After(cutoff) {
+					alive = append(alive, t)
+				}
+			}
+			if len(alive) == 0 {
+				delete(l.hits, k)
+			} else {
+				l.hits[k] = alive
+			}
+		}
+		l.mu.Unlock()
+	}
+}
+
+// clientIP extracts the caller's IP for rate-limiting. It uses the RIGHTMOST
+// X-Forwarded-For entry — the hop appended by the trusted front proxy (parapet),
+// i.e. the peer parapet actually saw — not the leftmost, which is client-supplied
+// and therefore spoofable (an attacker could rotate it to evade the per-IP cap).
+// Falls back to RemoteAddr when no XFF is present.
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		parts := strings.Split(xff, ",")
+		return strings.TrimSpace(parts[len(parts)-1])
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/register.go
+++ b/register.go
@@ -13,9 +13,22 @@ import (
 // CLIs use to obtain a client_id without manual provisioning.
 type RegisterHandler struct {
 	BaseURL string
+	// Limiter caps registrations per source IP. nil disables limiting (tests).
+	Limiter *registerLimiter
 }
 
 func (h RegisterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.Limiter != nil && !h.Limiter.allow(clientIP(r)) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusTooManyRequests)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error":             "too_many_requests",
+			"error_description": "registration rate limit exceeded; retry later",
+		})
+		return
+	}
+
 	var req struct {
 		ClientName              string   `json:"client_name"`
 		RedirectURIs            []string `json:"redirect_uris"`

--- a/register_test.go
+++ b/register_test.go
@@ -62,8 +62,10 @@ func TestRegisterHandler_HTTPSRedirectAllowed(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want 201; body=%s", rec.Code, rec.Body.String())
 	}
-	if n := countRows(t, ctx, "oauth2_clients"); n != 1 {
-		t.Errorf("oauth2_clients = %d, want 1", n)
+	// One client from this registration, plus the seeded deploys-cli fixture the
+	// migration always installs.
+	if n := countRows(t, ctx, "oauth2_clients"); n != 2 {
+		t.Errorf("oauth2_clients = %d, want 2 (1 registered + seeded deploys-cli)", n)
 	}
 }
 

--- a/schema/04_client_lifecycle.sql
+++ b/schema/04_client_lifecycle.sql
@@ -1,0 +1,15 @@
+-- Bound dynamically-registered (DCR) public clients so abandoned ones can be
+-- reaped, without ever touching operator-seeded or confidential clients.
+
+-- Mark which clients were created via Dynamic Client Registration (RFC 7591).
+-- Only these are eligible for idle GC; everything else (dynamically_registered =
+-- false: the Google web client, operator-seeded public clients) is never reaped.
+alter table oauth2_clients add column if not exists dynamically_registered bool        not null default false;
+
+-- last_used_at is stamped at each authorize so GC can reap by IDLE time, not by
+-- creation age — an actively-reused client (the CLI reuses one client_id) never
+-- expires. Null until first use; GC falls back to created_at for never-used rows.
+alter table oauth2_clients add column if not exists last_used_at            timestamptz;
+
+create index if not exists oauth2_clients_gc_idx
+	on oauth2_clients (dynamically_registered, last_used_at);

--- a/schema/05_seed_cli_client.sql
+++ b/schema/05_seed_cli_client.sql
@@ -1,0 +1,11 @@
+-- Seed the well-known public client the deploys CLI bakes in, so ordinary CLI
+-- logins never call /register (which would mint a permanent row per machine).
+--
+-- It is operator-seeded, so dynamically_registered keeps its default of false
+-- and the GC never reaps it. The port-less loopback redirect matches any
+-- 127.0.0.1:<port>/callback (the auth server ignores the port for loopback
+-- hosts). Pure DML, kept in its own migration so it never shares an implicit
+-- transaction with the column-adding DDL in 04. Idempotent.
+insert into oauth2_clients (id, secret, redirect_uris, token_endpoint_auth_method, client_name)
+values ('deploys-cli', null, array['http://127.0.0.1/callback'], 'none', 'deploys CLI')
+on conflict (id) do nothing;


### PR DESCRIPTION
## Why

`/register` (Dynamic Client Registration) is **unauthenticated** and inserts a **permanent** `oauth2_clients` row with no TTL. Every `deploys login` on a fresh machine/CI container that lacks a cached `client_id` mints a new row, and anyone can spam `/register` to bloat the table. The cleanup worker previously left clients alone on purpose (`"Registered clients are never reaped — MCP clients reuse their client_id"`). This bounds the surface three ways.

## What

1. **Seed a well-known CLI client** (`schema/05_seed_cli_client.sql`): a public `deploys-cli` client with the port-less loopback redirect `http://127.0.0.1/callback`. The deploys CLI bakes this id in, so ordinary logins **never call `/register`**. It is operator-seeded (`dynamically_registered = false`), so GC never reaps it.

2. **Idle GC of DCR clients** (`schema/04_client_lifecycle.sql` + `cleanup.go`):
   - New columns `dynamically_registered bool` and `last_used_at timestamptz` (+ a GC index).
   - `RegisterHandler` marks DCR inserts `dynamically_registered = true`; the authorize handler stamps `last_used_at = now()` on every use.
   - The cleanup worker reaps DCR clients idle past **90 days** (`coalesce(last_used_at, created_at)`). Reaps by **idle time, not creation age**, so a reused client (the CLI/MCP reuse one id) never expires. Non-DCR clients (the Google web client, operator-seeded ones) are never matched.

3. **Rate-limit `/register`** (`ratelimit.go`): per-source-IP, in-memory, 20/hour. Uses the **rightmost** `X-Forwarded-For` entry — the proxy-appended hop — since the leftmost is client-supplied and spoofable. This is the burst control that complements the steady-state GC.

The CLI is GC-safe: it re-registers on `invalid_client`/timeout, so reaping an idle client costs only a transparent one-time re-register.

## Migration / deploy notes

- Migration **04** (DDL: columns + index) and **05** (DML: the seed INSERT) are **separate files** so CockroachDB never mixes a schema change and DML in one implicit transaction. Both are idempotent (`add column if not exists`, `on conflict do nothing`).
- The seed makes the companion CLI change (deploys-app/deploys#43, which bakes in `deploys-cli`) work without per-machine DCR. **Apply this auth migration before that CLI ships**; if not, the CLI self-heals via DCR after one browser timeout.
- No new env vars. The Google web client and existing confidential clients are untouched.

### Seed SQL (for manual application)

```sql
insert into oauth2_clients (id, secret, redirect_uris, token_endpoint_auth_method, client_name)
values ('deploys-cli', null, array['http://127.0.0.1/callback'], 'none', 'deploys CLI')
on conflict (id) do nothing;
```

## Testing

`go build`, `go vet`, `go test ./...` all green (CRDB testserver). New tests cover: the seed is present + public + non-DCR, DCR registrations are marked, authorize stamps `last_used_at`, GC reaps idle DCR clients while keeping fresh/seeded/non-DCR ones, the per-IP limiter, and rightmost-XFF extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)