### PR TITLE
ci: build via shared remote buildkit endpoint

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Build
     steps:
       - uses: actions/checkout@v3
@@ -21,7 +21,8 @@ jobs:
           password: ${{ steps.auth.outputs.access_token }}
       - uses: docker/setup-buildx-action@v2
         with:
-          version: latest
+          driver: remote
+          endpoint: ${{ secrets.REMOTE_BUILD_ENDPOINT }}
       - uses: docker/build-push-action@v4
         with:
           provenance: false


### PR DESCRIPTION
## What

Build the Docker image against the shared remote BuildKit instance so every
build reuses one warm layer cache.

- `docker/setup-buildx-action` now uses `driver: remote` with
  `endpoint: ${{ secrets.REMOTE_BUILD_ENDPOINT }}`, replacing the per-run
  ephemeral local builder (`version: latest`).
- `runs-on: self-hosted` so the runner can reach the private BuildKit endpoint.

## Why

A single long-lived BuildKit instance keeps the layer cache warm across builds,
so repeated builds are significantly faster than re-warming a fresh local
builder every run.

## Notes

- Requires the `REMOTE_BUILD_ENDPOINT` repo secret (already configured) and a
  self-hosted runner with network reach to that endpoint.
- If the endpoint later requires mTLS, add `driver-opts` with `cacert`/`cert`/`key`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UujJC8ThyuTr9EwZjnwcox
