### PR TITLE
feat(token): add refresh_token grant for public clients

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,8 @@ This is a minimal OAuth2 authentication service for Deploys.app. It acts as an O
 |---|---|---|---|
 | `GET` | `/` | `RedirectHandler` | Validates the OAuth2 client and redirects the user to Google |
 | `GET` | `/callback` | `CallbackHandler` | Receives Google's code, exchanges it for an ID token, issues an internal auth code |
-| `POST` | `/token` | `TokenHandler` | Exchanges client credentials + internal code for a long-lived user token |
-| `POST` | `/revoke` | `RevokePostHandler` | Deletes a user token by its hash |
+| `POST` | `/token` | `TokenHandler` | Exchanges an auth code (`authorization_code`) or a refresh token (`refresh_token`) for an access token |
+| `POST` | `/revoke` | `RevokePostHandler` | Deletes an access or refresh token by its hash |
 
 ### Database access pattern
 
@@ -55,7 +55,8 @@ All DB logic lives in `oauth2.go` (session/code helpers) and `token.go` (token h
 
 - **OAuth2 sessions** (`oauth2_sessions`) — created by `RedirectHandler`, deleted on first read by `CallbackHandler`. 1-hour TTL enforced in the WHERE clause.
 - **OAuth2 codes** (`oauth2_codes`) — created by `CallbackHandler`, consumed atomically (DELETE … RETURNING) by `TokenHandler`. 1-hour TTL.
-- **User tokens** (`user_tokens`) — 7-day TTL, stored as SHA-256 hashes. Revoked by `RevokePostHandler`.
+- **User tokens** (`user_tokens`) — access tokens, 7-day TTL, stored as SHA-256 hashes. Revoked by `RevokePostHandler`.
+- **Refresh tokens** (`refresh_tokens`) — issued to public clients alongside the access token; single-use/rotating, client-bound, 30-day sliding TTL, stored as SHA-256 hashes. Exchanged for a fresh access token via `grant_type=refresh_token`. Kept out of `user_tokens` so they can never be used as an API bearer.
 
 ### Key decisions
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ the service starts.
 | `GET` | `/.well-known/oauth-authorization-server` | OAuth 2.0 Authorization Server Metadata (RFC 8414) |
 | `GET` | `/` | Validate the OAuth2 client and redirect to Google (authorize endpoint; supports PKCE) |
 | `GET` | `/callback` | Receive Google's code and issue an internal auth code |
-| `POST` | `/token` | Exchange code (+ secret or PKCE verifier) for a user token |
+| `POST` | `/token` | Exchange code (+ secret or PKCE verifier) for a user token, or a refresh token for a fresh one |
 | `POST` | `/register` | Dynamic Client Registration for public clients (RFC 7591) |
 | `POST` | `/introspect` | Token introspection for resource servers (RFC 7662) |
-| `POST` | `/revoke` | Revoke a user token |
+| `POST` | `/revoke` | Revoke an access token or a refresh token by its value |
 
 ### MCP / public clients
 
@@ -49,6 +49,21 @@ the authorize and token endpoints, and may use loopback redirect URIs
 (`http://127.0.0.1:<port>`). Confidential web clients keep using
 `client_secret` as before. A resource server validates issued bearer tokens via
 `/introspect` (authenticated with `INTROSPECTION_TOKEN`).
+
+### Refresh tokens
+
+The access token issued at `/token` is short-lived (7 days). Public clients
+(CLI / MCP connector) also receive a **refresh token** and can exchange it for a
+fresh access token with `grant_type=refresh_token` (`client_id` +
+`refresh_token`), so a connector no longer breaks mid-session on expiry — it
+silently refreshes instead of forcing a full browser re-authorization.
+
+Refresh tokens are **single-use and rotating**: every refresh returns a new
+refresh token and invalidates the one presented (a replayed token is rejected
+with `invalid_grant`). They live in their own `refresh_tokens` table (never
+`user_tokens`), are bound to the issuing client, and have a longer, sliding TTL
+(30 days, reset on each use). Confidential web clients keep their cookie session
+and do not use this grant — they receive no refresh token.
 
 `/register` mints a permanent public-client row, so it is **rate-limited per
 source IP** and dynamically-registered clients are **garbage-collected when idle**

--- a/cleanup.go
+++ b/cleanup.go
@@ -33,6 +33,7 @@ func cleanupExpired(db *sql.DB) {
 	for _, q := range []string{
 		`delete from oauth2_sessions where created_at < now() - interval '1 hour'`,
 		`delete from oauth2_codes where created_at < now() - interval '1 hour'`,
+		`delete from refresh_tokens where expires_at < now()`,
 	} {
 		if _, err := db.ExecContext(ctx, q); err != nil {
 			slog.ErrorContext(ctx, "cleanup: delete expired rows", "error", err)

--- a/handler.go
+++ b/handler.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"crypto/subtle"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -296,9 +298,7 @@ func (RevokeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	hashedToken := hashToken(token)
-	_, err := pgctx.Exec(ctx, `delete from user_tokens where token = $1`, hashedToken)
-	if err != nil {
+	if err := revokeToken(ctx, hashToken(token)); err != nil {
 		slog.ErrorContext(ctx, "revoke: delete token", "error", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
@@ -324,9 +324,7 @@ func (RevokePostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	hashedToken := hashToken(token)
-	_, err = pgctx.Exec(ctx, `delete from user_tokens where token = $1`, hashedToken)
-	if err != nil {
+	if err := revokeToken(ctx, hashToken(token)); err != nil {
 		slog.ErrorContext(ctx, "revoke: delete token", "error", err)
 		apiErrorResponse(w, http.StatusInternalServerError, "internal server error")
 		return
@@ -337,9 +335,14 @@ func (RevokePostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type TokenHandler struct{}
 
 func (TokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	grantType := r.PostFormValue("grant_type")
-	if grantType != "" && grantType != "authorization_code" {
-		oauthError(w, http.StatusBadRequest, "unsupported_grant_type", "only authorization_code is supported")
+	switch r.PostFormValue("grant_type") {
+	case "refresh_token":
+		handleRefreshTokenGrant(w, r)
+		return
+	case "", "authorization_code":
+		// fall through to the authorization_code exchange below
+	default:
+		oauthError(w, http.StatusBadRequest, "unsupported_grant_type", "unsupported grant_type")
 		return
 	}
 
@@ -417,25 +420,120 @@ func (TokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	token := generateToken()
-	hashedToken := hashToken(token)
-	err = insertToken(ctx, hashedToken, oauth2Code.Email)
+	err = insertToken(ctx, hashToken(token), oauth2Code.Email, tokenTTLSeconds)
 	if err != nil {
 		slog.ErrorContext(ctx, "token: insert token", "error", err)
 		oauthError(w, http.StatusInternalServerError, "server_error", "")
 		return
 	}
 
-	var resp struct {
+	// Public clients (CLI / MCP connector) get a real, rotating refresh token so
+	// they can silently refresh instead of forcing a full re-auth on expiry.
+	// Confidential clients (the web console) maintain their own cookie session and
+	// never use the refresh grant; the refresh_token field is echoed as the access
+	// token purely so the legacy web client keeps reading a non-empty value.
+	refreshToken := token
+	if oauth2Client.IsPublic() {
+		refreshToken = generateRefreshToken()
+		if err := insertRefreshToken(ctx, hashToken(refreshToken), oauth2Code.Email, clientID, refreshTokenTTLSeconds); err != nil {
+			slog.ErrorContext(ctx, "token: insert refresh token", "error", err)
+			oauthError(w, http.StatusInternalServerError, "server_error", "")
+			return
+		}
+	}
+
+	writeTokenResponse(w, token, refreshToken, tokenTTLSeconds)
+}
+
+// handleRefreshTokenGrant implements the RFC 6749 refresh_token grant. It rotates
+// the presented refresh token (single-use) and issues a fresh access/refresh
+// pair, so a client refreshing within the refresh-token window never needs a full
+// re-authorization.
+func handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request) {
+	clientID := r.PostFormValue("client_id")
+	if clientID == "" {
+		oauthError(w, http.StatusBadRequest, "invalid_request", "missing client_id")
+		return
+	}
+	presented := r.PostFormValue("refresh_token")
+	if presented == "" {
+		oauthError(w, http.StatusBadRequest, "invalid_request", "missing refresh_token")
+		return
+	}
+
+	ctx := r.Context()
+	oauth2Client, err := getOAuth2Client(ctx, clientID)
+	if errors.Is(err, ErrOAuth2ClientNotFound) {
+		oauthError(w, http.StatusUnauthorized, "invalid_client", "unknown client_id")
+		return
+	}
+	if err != nil {
+		slog.ErrorContext(ctx, "token: refresh: get oauth2 client", "error", err)
+		oauthError(w, http.StatusInternalServerError, "server_error", "")
+		return
+	}
+
+	// Confidential clients must still present their secret. Public clients are
+	// authenticated by possession of the single-use, client-bound refresh token
+	// itself — there is no PKCE on the refresh grant (no authorization code).
+	if !oauth2Client.IsPublic() {
+		clientSecret := r.PostFormValue("client_secret")
+		if clientSecret == "" {
+			oauthError(w, http.StatusBadRequest, "invalid_request", "missing client_secret")
+			return
+		}
+		if subtle.ConstantTimeCompare([]byte(clientSecret), []byte(oauth2Client.Secret)) != 1 {
+			oauthError(w, http.StatusUnauthorized, "invalid_client", "invalid client_secret")
+			return
+		}
+	}
+
+	// Rotate atomically: consume the old token and mint the new pair in one
+	// transaction. On any failure the transaction rolls back and the presented
+	// refresh token stays valid, so the client can simply retry.
+	var accessToken, newRefresh string
+	err = pgctx.RunInTx(ctx, func(ctx context.Context) error {
+		email, err := consumeRefreshToken(ctx, hashToken(presented), clientID)
+		if err != nil {
+			return err
+		}
+		accessToken = generateToken()
+		if err := insertToken(ctx, hashToken(accessToken), email, tokenTTLSeconds); err != nil {
+			return err
+		}
+		newRefresh = generateRefreshToken()
+		return insertRefreshToken(ctx, hashToken(newRefresh), email, clientID, refreshTokenTTLSeconds)
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		slog.WarnContext(ctx, "token: refresh: invalid refresh_token", "client_id", clientID)
+		oauthError(w, http.StatusBadRequest, "invalid_grant", "invalid or expired refresh_token")
+		return
+	}
+	if err != nil {
+		slog.ErrorContext(ctx, "token: refresh: rotate", "error", err)
+		oauthError(w, http.StatusInternalServerError, "server_error", "")
+		return
+	}
+
+	// Stamp last use so an actively-refreshing client is not reaped by idle GC,
+	// which otherwise only sees authorize-time activity.
+	touchClientLastUsed(ctx, clientID)
+
+	writeTokenResponse(w, accessToken, newRefresh, tokenTTLSeconds)
+}
+
+func writeTokenResponse(w http.ResponseWriter, accessToken, refreshToken string, expiresIn int) {
+	resp := struct {
 		AccessToken  string `json:"access_token"`
 		TokenType    string `json:"token_type"`
 		ExpiresIn    int    `json:"expires_in"`
 		RefreshToken string `json:"refresh_token"`
+	}{
+		AccessToken:  accessToken,
+		TokenType:    "Bearer",
+		ExpiresIn:    expiresIn,
+		RefreshToken: refreshToken,
 	}
-	resp.AccessToken = token
-	resp.TokenType = "Bearer"
-	resp.ExpiresIn = tokenTTLSeconds
-	resp.RefreshToken = token // retained for backward compatibility with the existing web client
-
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
 	json.NewEncoder(w).Encode(resp)

--- a/metadata.go
+++ b/metadata.go
@@ -21,7 +21,7 @@ func (h MetadataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"revocation_endpoint":                   h.BaseURL + "/revoke",
 		"introspection_endpoint":                h.BaseURL + "/introspect",
 		"response_types_supported":              []string{"code"},
-		"grant_types_supported":                 []string{"authorization_code"},
+		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
 		"code_challenge_methods_supported":      []string{"S256"},
 		"token_endpoint_auth_methods_supported": []string{"client_secret_post", "none"},
 	}

--- a/refresh_test.go
+++ b/refresh_test.go
@@ -1,0 +1,336 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// decodeTokenResponse reads the standard /token JSON body.
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+func decodeTokenResponse(t *testing.T, rec *httptest.ResponseRecorder) tokenResponse {
+	t.Helper()
+	var resp tokenResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	return resp
+}
+
+// --- authorization_code path now issues real refresh tokens for public clients ---
+
+func TestTokenHandler_Public_IssuesRealRefreshToken(t *testing.T) {
+	t.Parallel()
+	verifier, challenge := pkcePair()
+	const redirect = "http://127.0.0.1:5000/callback"
+
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx()
+	seedPublicClient(t, ctx, "cli", redirect)
+	seedCode(t, ctx, "abc", "cli", "user@example.com", challenge, "S256", redirect, "")
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {"cli"},
+		"code":          {"abc"},
+		"code_verifier": {verifier},
+		"redirect_uri":  {redirect},
+	}
+	rec := httptest.NewRecorder()
+	TokenHandler{}.ServeHTTP(rec, postForm(t, "/token", form).WithContext(ctx))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	resp := decodeTokenResponse(t, rec)
+
+	// The refresh token is a distinct, refresh-prefixed credential — not the
+	// access token echoed back.
+	if !strings.HasPrefix(resp.RefreshToken, refreshTokenPrefix) {
+		t.Errorf("refresh_token %q missing prefix %q", resp.RefreshToken, refreshTokenPrefix)
+	}
+	if resp.RefreshToken == resp.AccessToken {
+		t.Error("refresh_token must differ from access_token for public clients")
+	}
+	// It is persisted (hashed) against the right email and client.
+	if email, ok := refreshTokenEmail(t, ctx, hashToken(resp.RefreshToken)); !ok || email != "user@example.com" {
+		t.Errorf("persisted refresh token email = %q (ok=%v), want user@example.com", email, ok)
+	}
+}
+
+func TestTokenHandler_Confidential_NoRefreshTokenRow(t *testing.T) {
+	t.Parallel()
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx()
+	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/cb")
+	seedCode(t, ctx, "abc", "web", "user@example.com", "", "", "https://app.example.com/cb", "")
+
+	form := url.Values{"client_id": {"web"}, "client_secret": {"topsecret"}, "code": {"abc"}}
+	rec := httptest.NewRecorder()
+	TokenHandler{}.ServeHTTP(rec, postForm(t, "/token", form).WithContext(ctx))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	resp := decodeTokenResponse(t, rec)
+	// Legacy contract preserved: confidential clients get the access token echoed
+	// as refresh_token, and no refresh_tokens row is minted.
+	if resp.RefreshToken != resp.AccessToken {
+		t.Errorf("access_token (%q) should equal refresh_token (%q) for confidential clients", resp.AccessToken, resp.RefreshToken)
+	}
+	if n := countRows(t, ctx, "refresh_tokens"); n != 0 {
+		t.Errorf("refresh_tokens = %d, want 0 (confidential clients get no real refresh token)", n)
+	}
+}
+
+// --- refresh_token grant ---
+
+func TestRefreshTokenGrant_Success(t *testing.T) {
+	t.Parallel()
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx()
+	seedPublicClient(t, ctx, "cli", "http://127.0.0.1:5000/callback")
+	oldRefresh := generateRefreshToken()
+	seedRefreshToken(t, ctx, hashToken(oldRefresh), "user@example.com", "cli")
+
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {"cli"},
+		"refresh_token": {oldRefresh},
+	}
+	rec := httptest.NewRecorder()
+	TokenHandler{}.ServeHTTP(rec, postForm(t, "/token", form).WithContext(ctx))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	resp := decodeTokenResponse(t, rec)
+
+	if !strings.HasPrefix(resp.AccessToken, tokenPrefix) {
+		t.Errorf("access_token %q missing prefix %q", resp.AccessToken, tokenPrefix)
+	}
+	if !strings.HasPrefix(resp.RefreshToken, refreshTokenPrefix) {
+		t.Errorf("refresh_token %q missing prefix %q", resp.RefreshToken, refreshTokenPrefix)
+	}
+	if resp.RefreshToken == oldRefresh {
+		t.Error("refresh token must rotate (new value), got the same value back")
+	}
+	if resp.TokenType != "Bearer" {
+		t.Errorf("token_type = %q, want Bearer", resp.TokenType)
+	}
+	if resp.ExpiresIn != tokenTTLSeconds {
+		t.Errorf("expires_in = %d, want %d", resp.ExpiresIn, tokenTTLSeconds)
+	}
+	// A fresh access token is persisted for the user.
+	if email, ok := tokenEmail(t, ctx, hashToken(resp.AccessToken)); !ok || email != "user@example.com" {
+		t.Errorf("persisted access token email = %q (ok=%v), want user@example.com", email, ok)
+	}
+	// The old refresh token is consumed; the new one is persisted.
+	if _, ok := refreshTokenEmail(t, ctx, hashToken(oldRefresh)); ok {
+		t.Error("old refresh token must be consumed (single-use)")
+	}
+	if email, ok := refreshTokenEmail(t, ctx, hashToken(resp.RefreshToken)); !ok || email != "user@example.com" {
+		t.Errorf("rotated refresh token email = %q (ok=%v), want user@example.com", email, ok)
+	}
+	if n := countRows(t, ctx, "refresh_tokens"); n != 1 {
+		t.Errorf("refresh_tokens = %d, want 1 (old consumed, new minted)", n)
+	}
+}
+
+func TestRefreshTokenGrant_RotatedTokenRejected(t *testing.T) {
+	t.Parallel()
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx()
+	seedPublicClient(t, ctx, "cli", "http://127.0.0.1:5000/callback")
+	oldRefresh := generateRefreshToken()
+	seedRefreshToken(t, ctx, hashToken(oldRefresh), "user@example.com", "cli")
+
+	form := url.Values{"grant_type": {"refresh_token"}, "client_id": {"cli"}, "refresh_token": {oldRefresh}}
+
+	// First use succeeds.
+	rec := httptest.NewRecorder()
+	TokenHandler{}.ServeHTTP(rec, postForm(t, "/token", form).WithContext(ctx))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first refresh status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Replaying the now-rotated token fails.
+	rec = httptest.NewRecorder()
+	TokenHandler{}.ServeHTTP(rec, postForm(t, "/token", form).WithContext(ctx))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("replayed refresh status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	assertOAuthError(t, rec, "invalid_grant")
+}
+
+func TestRefreshTokenGrant_Expired(t *testing.T) {
+	t.Parallel()
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx()
+	seedPublicClient(t, ctx, "cli", "http://127.0.0.1:5000/callback")
+	expired := generateRefreshToken()
+	if _, err := pgctxExec(t, ctx, `
+		insert into refresh_tokens (token, email, client_id, expires_at)
+		values ($1, $2, $3, now() - interval '1 hour')
+	`, hashToken(expired), "user@example.com", "cli"); err != nil {
+		t.Fatalf("seed expired refresh token: %v", err)
+	}
+
+	form := url.Values{"grant_type": {"refresh_token"}, "client_id": {"cli"}, "refresh_token": {expired}}
+	rec := httptest.NewRecorder()
+	TokenHandler{}.ServeHTTP(rec, postForm(t, "/token", form).WithContext(ctx))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	assertOAuthError(t, rec, "invalid_grant")
+	if n := countRows(t, ctx, "user_tokens"); n != 0 {
+		t.Errorf("user_tokens = %d, want 0 (no access token on expired refresh)", n)
+	}
+}
+
+func TestRefreshTokenGrant_WrongClient(t *testing.T) {
+	t.Parallel()
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx()
+	seedPublicClient(t, ctx, "owner", "http://127.0.0.1:5000/callback")
+	seedPublicClient(t, ctx, "attacker", "http://127.0.0.1:6000/callback")
+	refresh := generateRefreshToken()
+	seedRefreshToken(t, ctx, hashToken(refresh), "user@example.com", "owner")
+
+	// Present the owner's refresh token under a different client_id.
+	form := url.Values{"grant_type": {"refresh_token"}, "client_id": {"attacker"}, "refresh_token": {refresh}}
+	rec := httptest.NewRecorder()
+	TokenHandler{}.ServeHTTP(rec, postForm(t, "/token", form).WithContext(ctx))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	assertOAuthError(t, rec, "invalid_grant")
+	// The owner's token must NOT be consumed by another client's attempt.
+	if _, ok := refreshTokenEmail(t, ctx, hashToken(refresh)); !ok {
+		t.Error("owner's refresh token must survive a foreign-client attempt")
+	}
+}
+
+func TestRefreshTokenGrant_MissingRefreshToken(t *testing.T) {
+	t.Parallel()
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx()
+	seedPublicClient(t, ctx, "cli", "http://127.0.0.1:5000/callback")
+
+	form := url.Values{"grant_type": {"refresh_token"}, "client_id": {"cli"}}
+	rec := httptest.NewRecorder()
+	TokenHandler{}.ServeHTTP(rec, postForm(t, "/token", form).WithContext(ctx))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	assertOAuthError(t, rec, "invalid_request")
+}
+
+func TestRefreshTokenGrant_MissingClientID(t *testing.T) {
+	t.Parallel()
+	form := url.Values{"grant_type": {"refresh_token"}, "refresh_token": {"deploys-refresh.x"}}
+	rec := httptest.NewRecorder()
+	// Rejected before any DB access.
+	TokenHandler{}.ServeHTTP(rec, postForm(t, "/token", form))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	assertOAuthError(t, rec, "invalid_request")
+}
+
+func TestRefreshTokenGrant_UnknownClient(t *testing.T) {
+	t.Parallel()
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx() // empty DB: client lookup misses
+
+	form := url.Values{"grant_type": {"refresh_token"}, "client_id": {"ghost"}, "refresh_token": {"deploys-refresh.x"}}
+	rec := httptest.NewRecorder()
+	TokenHandler{}.ServeHTTP(rec, postForm(t, "/token", form).WithContext(ctx))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	assertOAuthError(t, rec, "invalid_client")
+}
+
+func TestRevoke_RefreshToken(t *testing.T) {
+	t.Parallel()
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx()
+	seedPublicClient(t, ctx, "cli", "http://127.0.0.1:5000/callback")
+	refresh := generateRefreshToken()
+	seedRefreshToken(t, ctx, hashToken(refresh), "user@example.com", "cli")
+
+	// Revoke by presenting the refresh token value.
+	req := httptest.NewRequest(http.MethodPost, "/revoke", strings.NewReader(`{"token":"`+refresh+`"}`))
+	rec := httptest.NewRecorder()
+	RevokePostHandler{}.ServeHTTP(rec, req.WithContext(ctx))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("revoke status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// The refresh token is deleted and can no longer be exchanged.
+	if _, ok := refreshTokenEmail(t, ctx, hashToken(refresh)); ok {
+		t.Error("refresh token must be deleted after revoke")
+	}
+	form := url.Values{"grant_type": {"refresh_token"}, "client_id": {"cli"}, "refresh_token": {refresh}}
+	rec = httptest.NewRecorder()
+	TokenHandler{}.ServeHTTP(rec, postForm(t, "/token", form).WithContext(ctx))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("exchange of revoked refresh status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	assertOAuthError(t, rec, "invalid_grant")
+}
+
+func TestRefreshTokenGrant_Confidential_RequiresSecret(t *testing.T) {
+	t.Parallel()
+	tdb := newTestDB(t)
+	ctx := tdb.Ctx()
+	seedConfidentialClient(t, ctx, "web", "topsecret", "https://app.example.com/cb")
+	refresh := generateRefreshToken()
+	seedRefreshToken(t, ctx, hashToken(refresh), "user@example.com", "web")
+
+	// Missing secret → invalid_request.
+	form := url.Values{"grant_type": {"refresh_token"}, "client_id": {"web"}, "refresh_token": {refresh}}
+	rec := httptest.NewRecorder()
+	TokenHandler{}.ServeHTTP(rec, postForm(t, "/token", form).WithContext(ctx))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing secret: status = %d, want 400", rec.Code)
+	}
+	assertOAuthError(t, rec, "invalid_request")
+
+	// Wrong secret → invalid_client.
+	form.Set("client_secret", "wrong")
+	rec = httptest.NewRecorder()
+	TokenHandler{}.ServeHTTP(rec, postForm(t, "/token", form).WithContext(ctx))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong secret: status = %d, want 401", rec.Code)
+	}
+	assertOAuthError(t, rec, "invalid_client")
+
+	// The refresh token must survive both rejected attempts.
+	if _, ok := refreshTokenEmail(t, ctx, hashToken(refresh)); !ok {
+		t.Error("refresh token must not be consumed on failed client authentication")
+	}
+
+	// Correct secret → success.
+	form.Set("client_secret", "topsecret")
+	rec = httptest.NewRecorder()
+	TokenHandler{}.ServeHTTP(rec, postForm(t, "/token", form).WithContext(ctx))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("correct secret: status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/register.go
+++ b/register.go
@@ -77,7 +77,7 @@ func (h RegisterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"client_id_issued_at":        time.Now().Unix(),
 		"client_name":                req.ClientName,
 		"redirect_uris":              req.RedirectURIs,
-		"grant_types":                []string{"authorization_code"},
+		"grant_types":                []string{"authorization_code", "refresh_token"},
 		"response_types":             []string{"code"},
 		"token_endpoint_auth_method": "none",
 	}

--- a/schema/06_refresh_tokens.sql
+++ b/schema/06_refresh_tokens.sql
@@ -1,0 +1,18 @@
+-- Refresh tokens: long-lived, single-use (rotating) credentials issued to public
+-- clients (CLI / MCP connector) alongside the short-lived access token, so they
+-- can silently obtain a fresh access token without a full re-authorization.
+--
+-- Stored as a SHA-256 hash and bound to the issuing client. Kept in its own table
+-- (not user_tokens) so a refresh token can never be presented as an API bearer:
+-- the apiserver and /introspect resolve only user_tokens. The FK cascade reaps a
+-- client's refresh tokens if the client itself is ever removed (idle DCR GC).
+create table if not exists refresh_tokens (
+	token      string,
+	email      string      not null,
+	client_id  string      not null,
+	created_at timestamptz not null default now(),
+	expires_at timestamptz not null,
+	primary key (token),
+	foreign key (client_id) references oauth2_clients (id) on delete cascade
+);
+create index if not exists refresh_tokens_expires_at_idx on refresh_tokens (expires_at);

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -90,12 +90,34 @@ func seedToken(t *testing.T, ctx context.Context, hashedToken, email string) {
 	}
 }
 
+// seedRefreshToken inserts a valid (non-expired) refresh token bound to clientID.
+func seedRefreshToken(t *testing.T, ctx context.Context, hashedToken, email, clientID string) {
+	t.Helper()
+	_, err := pgctx.Exec(ctx, `
+		insert into refresh_tokens (token, email, client_id, expires_at)
+		values ($1, $2, $3, now() + interval '30 days')
+	`, hashedToken, email, clientID)
+	if err != nil {
+		t.Fatalf("seed refresh token: %v", err)
+	}
+}
+
 // --- assertion helpers ---
 
 func tokenEmail(t *testing.T, ctx context.Context, hashedToken string) (string, bool) {
 	t.Helper()
 	var email string
 	err := pgctx.QueryRow(ctx, `select email from user_tokens where token = $1`, hashedToken).Scan(&email)
+	if err != nil {
+		return "", false
+	}
+	return email, true
+}
+
+func refreshTokenEmail(t *testing.T, ctx context.Context, hashedToken string) (string, bool) {
+	t.Helper()
+	var email string
+	err := pgctx.QueryRow(ctx, `select email from refresh_tokens where token = $1`, hashedToken).Scan(&email)
 	if err != nil {
 		return "", false
 	}

--- a/token.go
+++ b/token.go
@@ -5,15 +5,29 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"time"
 
 	"github.com/acoshift/pgsql/pgctx"
 )
 
 const tokenPrefix = "deploys-api."
 
-// tokenTTLSeconds mirrors the 7-day TTL applied to user_tokens rows; reported
-// to clients as expires_in.
+// refreshTokenPrefix tags refresh tokens distinctly from access tokens so the
+// two can never be confused. A refresh token lives in its own table and is only
+// ever accepted at /token; presented as an API bearer it is rejected, since the
+// apiserver and /introspect resolve only user_tokens.
+const refreshTokenPrefix = "deploys-refresh."
+
+// tokenTTLSeconds is the access-token lifetime. It is the single source of truth
+// for both the expires_in reported to clients and the user_tokens row's
+// expires_at (see insertToken), so the two can never drift.
 const tokenTTLSeconds = 7 * 24 * 60 * 60
+
+// refreshTokenTTLSeconds is the refresh-token lifetime. It is longer than the
+// access token and rotated on every use (see handleRefreshTokenGrant), giving a
+// sliding window: a client used at least once within this window keeps working
+// without a full re-authorization.
+const refreshTokenTTLSeconds = 30 * 24 * 60 * 60
 
 func generateBase64RandomString(s int) string {
 	b := make([]byte, s)
@@ -26,6 +40,10 @@ func generateBase64RandomString(s int) string {
 
 func generateToken() string {
 	return tokenPrefix + generateBase64RandomString(32)
+}
+
+func generateRefreshToken() string {
+	return refreshTokenPrefix + generateBase64RandomString(32)
 }
 
 func generateState() string {
@@ -51,17 +69,61 @@ func hashToken(token string) string {
 	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
 }
 
-func insertToken(ctx context.Context, hashedToken string, email string) error {
+// insertToken persists a hashed access token for email, expiring ttlSeconds from
+// now. expires_at is computed from the same value reported to the client as
+// expires_in, keeping the wire contract and the DB row in lockstep.
+func insertToken(ctx context.Context, hashedToken, email string, ttlSeconds int) error {
+	expiresAt := time.Now().Add(time.Duration(ttlSeconds) * time.Second)
 	_, err := pgctx.Exec(ctx, `
 		insert into user_tokens (token, email, expires_at)
-		values ($1, $2, now() + interval '7 days')
-	`, hashedToken, email)
+		values ($1, $2, $3)
+	`, hashedToken, email, expiresAt)
 	return err
+}
+
+// insertRefreshToken persists a hashed refresh token bound to the issuing client,
+// expiring ttlSeconds from now. Binding to client_id lets consumeRefreshToken
+// reject a token replayed by a different client.
+func insertRefreshToken(ctx context.Context, hashedToken, email, clientID string, ttlSeconds int) error {
+	expiresAt := time.Now().Add(time.Duration(ttlSeconds) * time.Second)
+	_, err := pgctx.Exec(ctx, `
+		insert into refresh_tokens (token, email, client_id, expires_at)
+		values ($1, $2, $3, $4)
+	`, hashedToken, email, clientID, expiresAt)
+	return err
+}
+
+// consumeRefreshToken atomically deletes a refresh token and returns its owner,
+// enforcing single-use rotation: each refresh token is valid at most once. It
+// returns sql.ErrNoRows when the token is unknown, expired, already rotated, or
+// bound to a different client — all of which the caller treats as invalid_grant.
+func consumeRefreshToken(ctx context.Context, hashedToken, clientID string) (email string, err error) {
+	err = pgctx.QueryRow(ctx, `
+		delete from refresh_tokens
+		where token = $1 and client_id = $2 and expires_at > now()
+		returning email
+	`, hashedToken, clientID).Scan(&email)
+	return
 }
 
 func deleteToken(ctx context.Context, token string) error {
 	_, err := pgctx.Exec(ctx, `delete from user_tokens where token = $1`, token)
 	return err
+}
+
+// revokeToken deletes a token by its hash from both the access-token and
+// refresh-token stores, so a caller can revoke either kind by presenting its
+// value (RFC 7009). The hashes never collide across the two tables, so one of the
+// deletes is always a harmless no-op. Without this a refresh token — long-lived
+// and rotating — could never be revoked, only waited out.
+func revokeToken(ctx context.Context, hashedToken string) error {
+	return pgctx.RunInTx(ctx, func(ctx context.Context) error {
+		if _, err := pgctx.Exec(ctx, `delete from user_tokens where token = $1`, hashedToken); err != nil {
+			return err
+		}
+		_, err := pgctx.Exec(ctx, `delete from refresh_tokens where token = $1`, hashedToken)
+		return err
+	})
 }
 
 // lookupToken resolves a hashed token to its owner email and expiry (unix


### PR DESCRIPTION
## Problem

Public clients (the **MCP connector** and CLI) get a short-lived access token with no way to renew it. When the 7-day token expires mid-session, the only recovery is a **full browser re-authorization** — the server has no refresh grant today (the `refresh_token` field in the `/token` response is a fake echo of the access token, kept for the legacy web client). For the hosted HTTP MCP connector, which is stateless and re-validates every request, this means long `publish → deploy → extendTTL` flows break on expiry and force the user to sign in again.

## What this does

Adds a real OAuth 2.0 `refresh_token` grant, contained entirely to the `auth` repo:

- **Issue:** `authorization_code` now mints a distinct, rotating refresh token for **public** clients alongside the access token. Confidential web clients keep their legacy echo and get no refresh token (they use a cookie session and never call the refresh grant).
- **Refresh:** `grant_type=refresh_token` (`client_id` + `refresh_token`) rotates the presented token (**single-use, client-bound**) and mints a fresh access/refresh pair inside one transaction. A client that refreshes at least once within the window never needs to re-authorize.
- **Isolation:** refresh tokens live in their own `refresh_tokens` table (never `user_tokens`) with a distinct `deploys-refresh.` prefix, so a refresh token can never be presented as an API bearer — apiserver and `/introspect` resolve only `user_tokens`.
- **Revocation:** `/revoke` now revokes **either** token type by value (RFC 7009). Previously a refresh token could not be revoked at all — found and fixed during review.
- **Discovery & hygiene:** `metadata` + DCR advertise `refresh_token`; the cleanup worker reaps expired refresh tokens; idle GC keeps an actively-refreshing client alive (`last_used_at` stamped on refresh, not just authorize).

Access-token TTL is unchanged (7 days, small blast radius). Refresh tokens are **30-day sliding** (TTL resets on each rotation). MCP needs **zero changes** — the connecting OAuth client performs the refresh, exactly where the spec puts it. Also collapses the duplicated 7-day TTL (Go const vs SQL literal) into the single `tokenTTLSeconds` source.

## Security notes

- Refresh tokens are stored SHA-256-hashed, single-use/rotating, client-bound, and now revocable.
- Rotation is single-use but does **not** do family-revocation reuse-detection (a replayed rotated token is rejected with `invalid_grant`, not cascaded to revoke descendants). Documented as future hardening — there's no lineage column to cascade on today.
- The benefit for the connector depends on the connecting OAuth client actually refreshing on 401 (true for spec-compliant clients; worth confirming against the real connector).

## Deploy gate

Apply migration `schema/06_refresh_tokens.sql` **before** rolling out this binary — public-client logins fail without the `refresh_tokens` table.

## Tests

New `refresh_test.go` covers: public code-exchange issues a real distinct refresh token; confidential exchange mints none; refresh success + rotation; replay of a rotated token rejected; expired token rejected; foreign-client token rejected (and not consumed); missing `refresh_token` / `client_id`; unknown client; confidential secret enforcement; and revoke-then-exchange of a refresh token. `go vet` clean, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)